### PR TITLE
bugfix: pinLimit is returned in msat

### DIFF
--- a/src/hooks/useNfc.ts
+++ b/src/hooks/useNfc.ts
@@ -151,7 +151,7 @@ export const useNfc = () => {
               } else {
                 //if the card has pin enabled
                 //check the amount didn't exceed the limit
-                const limitSat = cardDataResponse.pinLimit;
+                const limitSat = cardDataResponse.pinLimit / 1000;
                 if (limitSat <= amount) {
                   setIsPinRequired(true);
                   pin = await getPin();


### PR DESCRIPTION
I read the spec wrong when I did the first implementation.

SERVICE returns pinLimit in mSats not Sats

https://github.com/bitcoin-ring/luds/blob/withdraw-pin/21.md